### PR TITLE
Code changes for renaming into trustee-operator

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -8,8 +8,8 @@ layout:
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}
-projectName: kbs-operator
-repo: github.com/confidential-containers/kbs-operator
+projectName: trustee-operator
+repo: github.com/confidential-containers/trustee-operator
 resources:
 - api:
     crdVersion: v1
@@ -17,6 +17,6 @@ resources:
   controller: true
   domain: confidentialcontainers.org
   kind: KbsConfig
-  path: github.com/confidential-containers/kbs-operator/api/v1alpha1
+  path: github.com/confidential-containers/trustee-operator/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# kbs-operator
+# trustee-operator
 
-The `kbs-operator` manages the lifecycle of [trustee](https://github.com/confidential-containers/trustee) along with it's configuration when deployed
+The `trustee-operator` manages the lifecycle of [trustee](https://github.com/confidential-containers/trustee) along with it's configuration when deployed
 in a Kubernetes cluster
 
 ## Description

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -4,7 +4,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=kbs-operator
+LABEL operators.operatorframework.io.bundle.package.v1=trustee-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/bundle/manifests/kbs-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kbs-operator-controller-manager-metrics-service_v1_service.yaml
@@ -4,13 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/part-of: trustee-operator
     control-plane: controller-manager
-  name: kbs-operator-controller-manager-metrics-service
+  name: trustee-operator-controller-manager-metrics-service
 spec:
   ports:
   - name: https

--- a/bundle/manifests/kbs-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kbs-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -4,12 +4,12 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/part-of: kbs-operator
-  name: kbs-operator-metrics-reader
+    app.kubernetes.io/part-of: trustee-operator
+  name: trustee-operator-metrics-reader
 rules:
 - nonResourceURLs:
   - /metrics

--- a/bundle/manifests/kbs-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kbs-operator.clusterserviceversion.yaml
@@ -9,11 +9,11 @@ metadata:
           "kind": "KbsConfig",
           "metadata": {
             "labels": {
-              "app.kubernetes.io/created-by": "kbs-operator",
+              "app.kubernetes.io/created-by": "trustee-operator",
               "app.kubernetes.io/instance": "kbsconfig-sample",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "kbsconfig",
-              "app.kubernetes.io/part-of": "kbs-operator"
+              "app.kubernetes.io/part-of": "trustee-operator"
             },
             "name": "kbsconfig-sample-sample",
             "namespace": "kbs-operator-system"
@@ -33,7 +33,7 @@ metadata:
     createdAt: "2024-04-29T09:43:48Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: kbs-operator.v0.0.1
+  name: trustee-operator.v0.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -44,8 +44,8 @@ spec:
       kind: KbsConfig
       name: kbsconfigs.confidentialcontainers.org
       version: v1alpha1
-  description: Operator to manage the lifecycle of Key Broker Service (KBS)
-  displayName: KBS Operator
+  description: Operator to manage the lifecycle of Trustee
+  displayName: Trustee Operator
   icon:
   - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTguNTEgMjU4LjUxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2QxZDFkMTt9LmNscy0ye2ZpbGw6IzhkOGQ4Zjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkFzc2V0IDQ8L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTI5LjI1LDIwQTEwOS4xLDEwOS4xLDAsMCwxLDIwNi40LDIwNi40LDEwOS4xLDEwOS4xLDAsMSwxLDUyLjExLDUyLjExLDEwOC40NSwxMDguNDUsMCwwLDEsMTI5LjI1LDIwbTAtMjBoMEM1OC4xNiwwLDAsNTguMTYsMCwxMjkuMjVIMGMwLDcxLjA5LDU4LjE2LDEyOS4yNiwxMjkuMjUsMTI5LjI2aDBjNzEuMDksMCwxMjkuMjYtNTguMTcsMTI5LjI2LTEyOS4yNmgwQzI1OC41MSw1OC4xNiwyMDAuMzQsMCwxMjkuMjUsMFoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzcuNTQsMTAzLjQxSDE0MS42NkwxNTQuOSw2NS43NmMxLjI1LTQuNC0yLjMzLTguNzYtNy4yMS04Ljc2SDEwMi45M2E3LjMyLDcuMzIsMCwwLDAtNy40LDZsLTEwLDY5LjYxYy0uNTksNC4xNywyLjg5LDcuODksNy40LDcuODloMzYuOUwxMTUuNTUsMTk3Yy0xLjEyLDQuNDEsMi40OCw4LjU1LDcuMjQsOC41NWE3LjU4LDcuNTgsMCwwLDAsNi40Ny0zLjQ4TDE4NCwxMTMuODVDMTg2Ljg2LDEwOS4yNCwxODMuMjksMTAzLjQxLDE3Ny41NCwxMDMuNDFaIi8+PC9nPjwvZz48L3N2Zz4=
     mediatype: image/svg+xml
@@ -142,11 +142,11 @@ spec:
       deployments:
       - label:
           app.kubernetes.io/component: manager
-          app.kubernetes.io/created-by: kbs-operator
+          app.kubernetes.io/created-by: trustee-operator
           app.kubernetes.io/instance: controller-manager
           app.kubernetes.io/managed-by: kustomize
           app.kubernetes.io/name: deployment
-          app.kubernetes.io/part-of: kbs-operator
+          app.kubernetes.io/part-of: trustee-operator
           control-plane: controller-manager
         name: kbs-operator-controller-manager
         spec:
@@ -294,13 +294,13 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - kbs
-  - kbs-operator
+  - trustee
+  - trustee-operator
   - attestation-service
   - rvps
   links:
-  - name: Kbs Operator
-    url: https://github.com/confidential-containers/kbs-operator
+  - name: Trustee Operator
+    url: https://github.com/confidential-containers/trustee-operator
   maintainers:
   - email: cncf-ccontainers-maintainers@lists.cncf.io
     name: Pradipta Banerjee

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -3,7 +3,7 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: kbs-operator
+  operators.operatorframework.io.bundle.package.v1: trustee-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,8 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/kbs-operator/api/v1alpha1"
-	controller "github.com/confidential-containers/kbs-operator/internal/controller"
+	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/trustee-operator/api/v1alpha1"
+	controller "github.com/confidential-containers/trustee-operator/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	//+kubebuilder:scaffold:imports
 )

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
@@ -24,8 +24,8 @@ metadata:
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:

--- a/config/manifests/bases/kbs-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kbs-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: kbs-operator.v0.0.0
+  name: trustee-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -34,13 +34,13 @@ spec:
   - supported: true
     type: AllNamespaces
   keywords:
-  - kbs
-  - kbs-operator
+  - trustee
+  - trustee-operator
   - attestation-service
   - rvps
   links:
   - name: Kbs Operator
-    url: https://github.com/confidential-containers/kbs-operator
+    url: https://github.com/confidential-containers/trustee-operator
   maintainers:
   - email: cncf-ccontainers-maintainers@lists.cncf.io
     name: Pradipta Banerjee

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: metrics-reader
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
   name: metrics-reader
 rules:

--- a/config/rbac/auth_proxy_role.yaml
+++ b/config/rbac/auth_proxy_role.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: proxy-role
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
   name: proxy-role
 rules:

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: proxy-rolebinding
     app.kubernetes.io/component: kube-rbac-proxy
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
   name: proxy-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: kbs-operator
-    app.kubernetes.io/part-of: kbs-operator
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/part-of: trustee-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/confidential-containers/kbs-operator
+module github.com/confidential-containers/trustee-operator
 
 go 1.21
 

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/kbs-operator/api/v1alpha1"
+	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/trustee-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
 )
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/kbs-operator/api/v1alpha1"
+	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/trustee-operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
New name applied for bundle/manifests.

No change to CRD api/images (maybe we can do that later)