### PR TITLE
bundle: Bump kbs image to its latest release

### DIFF
--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -192,7 +192,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: KBS_IMAGE_NAME
-                  value: quay.io/confidential-containers/trustee:290fd0eb64ab20f50efbd27cf80542851c0ee17f
+                  value: ghcr.io/confidential-containers/key-broker-service:v0.10.1
                 - name: AS_IMAGE_NAME
                   value: ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest
                 - name: RVPS_IMAGE_NAME


### PR DESCRIPTION
Let's ensure we're pointing to the latest (v0.10.1) kbs release, instead of a hash that's only present on quay.io.