### PR TITLE
Removal of ReadOnly part for PVCVolume

### DIFF
--- a/internal/controller/volumes.go
+++ b/internal/controller/volumes.go
@@ -139,7 +139,6 @@ func (r *KbsConfigReconciler) createPVCVolume(ctx context.Context, volumeName st
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: volumeName,
-				ReadOnly:  true,
 			},
 		},
 	}


### PR DESCRIPTION
- **Description of the problem which is fixed/What is the use case**
While testing remote attestation for IBM SE, we were having key fetching failure. After multiple debugging, we found that it is having permission issue because of below (Although pem file was there) -

**[2024-10-01T06:11:32Z INFO api_server::http::attest] Auth API called. [2024-10-01T06:11:32Z DEBUG api_server::http::attest] Auth Request: Json(Request { version: "0.1.0", tee: Se, extra_params: "" }) [2024-10-01T06:11:32Z *ERROR api_server::http::error] Authentication failed: generate challenge: Private key file does not exist: /run/confidential-containers/ibmse/rsa/encrypt_key.pem***

**What I did** -
Removed ReadOnly part from PVCVolume as below from deployment config:- 
- name: ibmse-pvc-1oct-new
        persistentVolumeClaim:
          claimName: ibmse-pvc-1oct-new
          readOnly: true // This line I had removed

- **Test Result**
```
root@a3elp36 gaurav-fresh-setup]# oc exec -it kbs-client -- kbs-client --url http://kbs-service:8080/ get-resource --path default/kbsres1/key1
XXXXXXXXXXX
[root@a3elp36 gaurav-fresh-setup]# oc exec -it kbs-client -- kbs-client --url http://kbs-service:8080/ get-resource --path default/kbsres1/key2
XXXXXXXXXXX
```