### PR TITLE
go.mod: bump Go toolchain version to v1.22.0

### DIFF
--- a/.github/workflows/kuttl-int-tests.yaml
+++ b/.github/workflows/kuttl-int-tests.yaml
@@ -16,11 +16,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
 
-    - uses: actions/setup-go@v2.1.4
+    - uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version-file: go.mod
+        check-latest: true
 
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.21 as builder
+FROM docker.io/golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/confidential-containers/trustee-operator
 
-go 1.21
+go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
As of Go 1.21, toolchain versions must use the 1.N.P syntax.

Moreover, since Go 1.21 is no longer maintained, bump to Go 1.22 with the new syntax.