### PR TITLE
actions: add arm64 image for release and PR merge

### DIFF
--- a/.github/workflows/docker-publish-latest-on-merge.yaml
+++ b/.github/workflows/docker-publish-latest-on-merge.yaml
@@ -68,6 +68,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/s390x
+          platforms: linux/amd64,linux/s390x,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish-on-tag.yaml
+++ b/.github/workflows/docker-publish-on-tag.yaml
@@ -62,6 +62,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/s390x
+          platforms: linux/amd64,linux/s390x,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR address one item in https://github.com/confidential-containers/trustee/issues/631 and will enable `trustee-operator` arm64 image build only. Thanks! @seungukshin great work for [Kbs](https://github.com/confidential-containers/trustee/issues/631#issuecomment-2545772912), I understand that the KBS arm64 image is still in developing. 