### PR TITLE
Revert CSV install mode

### DIFF
--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -217,13 +217,13 @@ spec:
         serviceAccountName: trustee-operator-controller-manager
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - trustee

--- a/config/manifests/bases/trustee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/trustee-operator.clusterserviceversion.yaml
@@ -29,13 +29,13 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   keywords:
   - trustee


### PR DESCRIPTION
Reverted install mode in CSV to allow publishing trustee-operator.v0.3.0 in the operator-hub as a replacement of v0.1.0