### PR TITLE
Update kbs-config.yaml

### DIFF
--- a/config/samples/microservices/kbs-config.yaml
+++ b/config/samples/microservices/kbs-config.yaml
@@ -17,7 +17,7 @@ data:
     insecure_key = true
 
     [attestation_service]
-    type = "coco_as_grpc"
+    type = "coco_as_builtin"
     as_addr = "http://127.0.0.1:50004"
 
     [[plugins]]


### PR DESCRIPTION
Got this error when deploying. 

```
kubectl logs trustee-deployment-6fc58df596-bswsc 
Defaulted container "kbs" out of: kbs, as, rvps
[2025-02-27T15:57:27Z INFO  kbs] Using config file /etc/kbs-config/kbs-config.toml
Error: invalid config: unknown variant `coco_as_grpc`, expected `CoCoASBuiltIn` or `coco_as_builtin`
```

updated  attestation_service type to `coco_as_builtin`. 
