### PR TITLE
ci: Enable kuttl integration tests for arm64

### DIFF
--- a/.github/workflows/kuttl-int-tests.yaml
+++ b/.github/workflows/kuttl-int-tests.yaml
@@ -12,7 +12,12 @@ env:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        instance:
+          - "ubuntu-22.04"
+          - "ubuntu-22.04-arm"
+    runs-on: ${{ matrix.instance }}
     steps:
 
     - uses: actions/setup-go@v5
@@ -23,10 +28,18 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo curl -Lo $KUTTL https://github.com/kudobuilder/kuttl/releases/download/v0.19.0/kubectl-kuttl_0.19.0_linux_x86_64
+        KUTTL_ARCH="x86_64"
+        KIND_ARCH="amd64"
+        if [ "$RUNNING_INSTANCE" == "ubuntu-22.04-arm" ]; then
+          KUTTL_ARCH="arm64"
+          KIND_ARCH="arm64"
+        fi
+        sudo curl -Lo $KUTTL https://github.com/kudobuilder/kuttl/releases/download/v0.19.0/kubectl-kuttl_0.19.0_linux_${KUTTL_ARCH}
         sudo chmod +x $KUTTL
-        sudo curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.22.0/kind-linux-amd64
+        sudo curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.22.0/kind-linux-${KIND_ARCH}
         sudo chmod +x kind
+      env:
+        RUNNING_INSTANCE: ${{ matrix.instance }}
 
     - name: "Run integration tests"
-      run: make test-e2e
+      run: KBS_IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY%/*}/staged-images/kbs:latest CLIENT_IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY%/*}/staged-images/kbs-client-image:latest make test-e2e

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -3,4 +3,4 @@ kind: TestSuite
 testDirs:
 - tests/e2e/
 parallel: 1
-timeout: 240
+timeout: 480


### PR DESCRIPTION
Enable kuttl integration tests for arm64. It uses staged images for `kbs` and `kbs-client` from trustee, it should be merged after https://github.com/confidential-containers/trustee/pull/769 is merged.

test results from the forked repo.:
* https://github.com/seungukshin/trustee-operator/actions/runs/14598388794