### PR TITLE
Add automatic cluster-wide proxy support

### DIFF
--- a/config/manifests/bases/trustee-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/trustee-operator.clusterserviceversion.yaml
@@ -6,6 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Security
     containerImage: quay.io/confidential-containers/trustee-operator:v0.5.0
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/suggested-namespace: trustee-operator-system
     support: Confidential Containers Community
   name: trustee-operator.v0.5.0

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,3 +70,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
+	github.com/openshift/api v0.0.0-20251020095937-6a0c921fc0f5
 	k8s.io/api v0.34.1
 	k8s.io/apimachinery v0.34.1
 	k8s.io/client-go v0.34.1

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.36.1 h1:bJDPBO7ibjxcbHMgSCoo4Yj18UWbKDlLwX1x9sybDcw=
 github.com/onsi/gomega v1.36.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/openshift/api v0.0.0-20251020095937-6a0c921fc0f5 h1:P3XSHKoFPx/vW/hzN1q7l7i8mRCX/vP+4g5AdLeaNOQ=
+github.com/openshift/api v0.0.0-20251020095937-6a0c921fc0f5/go.mod h1:d5uzF0YN2nQQFA0jIEWzzOZ+edmo6wzlGLvx5Fhz4uY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This commit implements proxy-aware functionality that automatically detects and applies cluster-wide proxy settings to trustee deployments.

Changes:
- Add OpenShift config API dependency for reading cluster Proxy object
- Implement getClusterProxyEnvVars() to fetch HTTP_PROXY, HTTPS_PROXY, and NO_PROXY from OpenShift cluster configuration
- Update buildEnvVars() to merge cluster proxy settings with user-specified KbsEnvVars (user settings override cluster settings)
- Add RBAC permissions to read proxies from config.openshift.io API group
- Update CSV to mark operator as proxy-aware (proxy-aware: true)

Fixes: #68