### PR TITLE
Set num of actix-web workers to 4 by default

### DIFF
--- a/config/samples/all-in-one/ita-kbs-config.yaml
+++ b/config/samples/all-in-one/ita-kbs-config.yaml
@@ -8,6 +8,7 @@ data:
     [http_server]
     sockets = ["0.0.0.0:8080"]
     insecure_http = true
+    worker_count = 4
 
     [admin]
     insecure_api = true

--- a/config/samples/all-in-one/kbs-config.yaml
+++ b/config/samples/all-in-one/kbs-config.yaml
@@ -8,6 +8,7 @@ data:
     [http_server]
     sockets = ["0.0.0.0:8080"]
     insecure_http = true
+    worker_count = 4
 
     [admin]
     insecure_api = true

--- a/config/samples/microservices/ita-kbs-config.yaml
+++ b/config/samples/microservices/ita-kbs-config.yaml
@@ -8,6 +8,7 @@ data:
     [http_server]
     sockets = ["0.0.0.0:8080"]
     insecure_http = true
+    worker_count = 4
 
     [admin]
     insecure_api = true

--- a/config/samples/microservices/kbs-config.yaml
+++ b/config/samples/microservices/kbs-config.yaml
@@ -8,6 +8,7 @@ data:
     [http_server]
     sockets = ["0.0.0.0:8080"]
     insecure_http = true
+    worker_count = 4
 
     [admin]
     insecure_api = true

--- a/config/templates/kbs-config-permissive.toml
+++ b/config/templates/kbs-config-permissive.toml
@@ -1,6 +1,7 @@
 [http_server]
 sockets = ["0.0.0.0:8080"]
 insecure_http = true
+worker_count = 4
 
 [admin]
 insecure_api = false

--- a/config/templates/kbs-config-restricted.toml
+++ b/config/templates/kbs-config-restricted.toml
@@ -3,6 +3,7 @@ sockets = ["0.0.0.0:8080"]
 insecure_http = false
 private_key = "/etc/https-key/privateKey"
 certificate = "/etc/https-cert/certificate"
+worker_count = 4
 
 [admin]
 insecure_api = false

--- a/tests/e2e/sample-attester-https/03-kbs-config.yaml
+++ b/tests/e2e/sample-attester-https/03-kbs-config.yaml
@@ -10,6 +10,7 @@ data:
     insecure_http = false
     private_key = "/etc/https-key/https.key"
     certificate = "/etc/https-cert/https.crt"
+    worker_count = 4
 
     [admin]
     insecure_api = true

--- a/tests/e2e/sample-attester/03-kbs-config.yaml
+++ b/tests/e2e/sample-attester/03-kbs-config.yaml
@@ -8,6 +8,7 @@ data:
     [http_server]
     sockets = ["0.0.0.0:8080"]
     insecure_http = true
+    worker_count = 4
 
     [admin]
     insecure_api = true

--- a/tests/scripts/config-trustee.sh
+++ b/tests/scripts/config-trustee.sh
@@ -15,6 +15,7 @@ data:
     [http_server]
     sockets = ["0.0.0.0:8080"]
     insecure_http = true
+    worker_count = 4
 
     [admin]
     insecure_api = true


### PR DESCRIPTION
Setting  the num of worker to 4 seems more reasonable.

When not set explicitly, the num of HTTP workers spawn by trustee is equal to the number of logical CPU cores available on the machine.
On systems with a high core count and hyper-threading enabled, this can result in an extremely large number of workers.
(in some cases, the "Too Many Open Files" system error can be hit)