### PR TITLE
fix: fall back to DefaultKbsImageName when KBS env var is unset

### DIFF
--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -706,6 +706,9 @@ func (r *KbsConfigReconciler) buildKbsContainer(volumeMounts []corev1.VolumeMoun
 	} else {
 		imageName = os.Getenv("KBS_IMAGE_NAME_MICROSERVICES")
 	}
+	if imageName == "" {
+		imageName = DefaultKbsImageName
+	}
 
 	// command array for the KBS container
 	command := []string{


### PR DESCRIPTION
buildKbsContainer read KBS_IMAGE_NAME / KBS_IMAGE_NAME_MICROSERVICES from the environment but had no fallback when the variable was empty. An empty Image field in the container spec causes an ErrImagePull failure at the kubelet with no actionable error from the operator.

buildAsContainer and buildRvpsContainer already fall back to their respective defaults; apply the same pattern to the KBS container using the existing DefaultKbsImageName constant.