### PR TITLE
Fix CI failure by updating Go builder image to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
go.mod requires go 1.25.0 / toolchain go1.25.9, but Dockerfile was pinned to golang:1.24, causing go mod download to fail at build time.