### PR TITLE
Fix out-of-memory issue when deploying the operator

### DIFF
--- a/bundle/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/trustee-operator.clusterserviceversion.yaml
@@ -184,10 +184,10 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 512Mi
                   requests:
                     cpu: 10m
-                    memory: 64Mi
+                    memory: 256Mi
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -115,9 +115,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Increased memory limits to avoid the out-of-memory issue