### PR TITLE
Feature/115/multi tenancy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -35,7 +35,7 @@ COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/secret-converter .
 
 # Copy the config templates
-COPY --from=builder /workspace/config/templates/ /config/templates/
+COPY --from=builder --chown=65532:65532 /workspace/config/templates/ /config/templates/
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/config/rbac/README.md
+++ b/config/rbac/README.md
@@ -1,0 +1,33 @@
+# Tenant RBAC Examples
+
+This directory contains example RBAC manifests for granting tenant users permission to create TrusteeConfigs in their namespace.
+
+## Setup
+
+```bash
+# Apply tenant ClusterRole (once per cluster)
+kubectl apply -f tenant-role.yaml
+
+# Create tenant namespace with Pod Security Admission labels
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <tenant-namespace>
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+EOF
+
+# Use a RoleBinding on the ClusterRole to limit permissions to the given Namespace
+# This is the CLI equivelant of tenant-rolebinding.yaml
+# For a User (--user) or ServiceAccount (--serviceaccount)
+kubectl create rolebinding tenant-user-trustee-config-creator \
+  --clusterrole=trustee-config-creator \
+  --user=<tenant-namespace>:<username> \
+  --serviceaccount=tenant-a:tenant-sa \
+  -n <tenant-namespace>
+
+# Tenant can now create TrusteeConfig in their namespace
+```

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get

--- a/config/rbac/tenant-role.yaml
+++ b/config/rbac/tenant-role.yaml
@@ -1,0 +1,21 @@
+# Example ClusterRole for tenant users to create and manage TrusteeConfigs
+# Use a RoleBinding to limit permissions to a single namespace, or ClusterRoleBinding for entire cluster scope
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trustee-config-creator
+rules:
+# Permission to create and manage TrusteeConfigs
+- apiGroups: ["confidentialcontainers.org"]
+  resources: ["trusteeconfigs"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+# Permission to view generated resources
+- apiGroups: [""]
+  resources: ["secrets", "configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list", "watch"]

--- a/config/rbac/tenant-rolebinding.yaml
+++ b/config/rbac/tenant-rolebinding.yaml
@@ -1,0 +1,18 @@
+# Example RoleBinding to grant a user the trustee-config-creator role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: <user>-trustee-config-creator
+  namespace: <tenant-namespace>  # Replace with actual namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustee-config-creator
+subjects:
+- kind: User
+  name: <tenant-user>  # Replace with actual username
+  apiGroup: rbac.authorization.k8s.io
+# Or use ServiceAccount:
+# - kind: ServiceAccount
+#   name: <service-account-name>
+#   namespace: <tenant-namespace>

--- a/config/templates/kbs-config-permissive.toml
+++ b/config/templates/kbs-config-permissive.toml
@@ -6,7 +6,10 @@ worker_count = 4
 [admin]
 type = "DenyAll"
 insecure_api = false
-auth_public_key = "/etc/auth-secret/publicKey"
+
+[[admin.personas]]
+id = "admin"
+public_key_path = "/etc/auth-secret/publicKey"
 
 [attestation_token]
 insecure_key = true

--- a/config/templates/kbs-config-restricted.toml
+++ b/config/templates/kbs-config-restricted.toml
@@ -8,7 +8,10 @@ worker_count = 4
 [admin]
 type = "DenyAll"
 insecure_api = false
-auth_public_key = "/etc/auth-secret/publicKey"
+
+[[admin.personas]]
+id = "admin"
+public_key_path = "/etc/auth-secret/publicKey"
 
 [attestation_token]
 insecure_key = false

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -32,12 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	confidentialcontainersorgv1alpha1 "github.com/confidential-containers/trustee-operator/api/v1alpha1"
@@ -96,6 +92,9 @@ func (r *KbsConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// KbsConfig instance is found, so continue with rest of the processing
+
+	// Use namespace from request so that we only reconcile resources relevant to the kbsConfig in the given namespace
+	r.namespace = req.Namespace
 
 	// Check if the KbsConfig object is marked to be deleted, which is
 	// indicated by the deletion timestamp being set.
@@ -176,7 +175,6 @@ func (r *KbsConfigReconciler) finalizeKbsConfig(ctx context.Context) error {
 // deployOrUpdateKbsService returns a new service for the KBS instance
 // Errors are logged by the callee and hence no error is logged in this method
 func (r *KbsConfigReconciler) deployOrUpdateKbsService(ctx context.Context) error {
-
 	// Check if the service name kbs-service in r.namespace already exists
 	// If it does, update the service
 	// If it does not, create the service
@@ -268,7 +266,6 @@ func (r *KbsConfigReconciler) newKbsService(ctx context.Context) *corev1.Service
 // Returns (created, error) where created is true when a new deployment was just made.
 // Errors are logged by the callee and hence no error is logged in this method
 func (r *KbsConfigReconciler) deployOrUpdateKbsDeployment(ctx context.Context) (bool, error) {
-
 	// Check if the deployment name kbs-deployment in r.namespace already exists
 	// If it does, update the deployment
 	// If it does not, create the deployment
@@ -905,13 +902,6 @@ func (r *KbsConfigReconciler) updateKbsDeployment(ctx context.Context, deploymen
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KbsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
-	// Get the namespace that the controller is running in
-	r.namespace = os.Getenv("POD_NAMESPACE")
-	if r.namespace == "" {
-		r.namespace = KbsOperatorNamespace
-	}
-
 	// Create a logr instance and assign it to r.log
 	r.log = ctrl.Log.WithName("kbsconfig-controller")
 	r.log = r.log.WithValues("kbsconfig", r.namespace)
@@ -930,7 +920,7 @@ func (r *KbsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Create a new controller and add a watch for KbsConfig including the following secondary resources:
-	// KbsConfigMap, KbsSecret, KbsAsConfigMap, KbsRvpsConfigMap in the same namespace as the controller
+	// KbsConfigMap, KbsSecret, KbsAsConfigMap, KbsRvpsConfigMap across all namespaces in the cluster
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&confidentialcontainersorgv1alpha1.KbsConfig{}).
 		// Watch externally-referenced ConfigMaps and Secrets (not owned by KbsConfig)
@@ -938,12 +928,10 @@ func (r *KbsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(configMapMapper),
-			builder.WithPredicates(namespacePredicate(r.namespace)),
 		).
 		Watches(
 			&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(secretMapper),
-			builder.WithPredicates(namespacePredicate(r.namespace)),
 		).
 		// Watch ConfigMaps and Secrets owned by KbsConfig so that accidental
 		// deletion triggers reconciliation and the controller recreates them.
@@ -1051,24 +1039,6 @@ func secretToKbsConfigMapper(c client.Client, log logr.Logger) (handler.MapFunc,
 	}
 
 	return mapperFunc, nil
-}
-
-// namespacePredicate is a custom predicate function that filters resources based on the namespace.
-func namespacePredicate(namespace string) predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			return isResourceInNamespace(e.Object, namespace)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return isResourceInNamespace(e.ObjectNew, namespace)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isResourceInNamespace(e.Object, namespace)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return isResourceInNamespace(e.Object, namespace)
-		},
-	}
 }
 
 // isResourceInNamespace checks if the resource is in the specified namespace.

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -59,6 +59,7 @@ type KbsConfigReconciler struct {
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;update
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=config.openshift.io,resources=proxies,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -904,7 +905,6 @@ func (r *KbsConfigReconciler) updateKbsDeployment(ctx context.Context, deploymen
 func (r *KbsConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Create a logr instance and assign it to r.log
 	r.log = ctrl.Log.WithName("kbsconfig-controller")
-	r.log = r.log.WithValues("kbsconfig", r.namespace)
 
 	// Create an event recorder for emitting Kubernetes events
 	r.Recorder = mgr.GetEventRecorderFor("kbsconfig-controller")


### PR DESCRIPTION
This empowers the operator to manage `trustee`' per namespace. If a `TrusteeConfig` is created inside a namespace `tenant-a` then the respective resources are deployed into `tenant-a`. 

I have successfully used this to create a `trustee` in `tenant-a` and `tenant-b`, i deployed the built operator into a local kind cluster as `make run` didn't work (paths in code assume location of `/templates` which resulted in things being very unhappy)

<details>
  <summary>Dev Loop</summary>
  
  Script used to iteratively build / deploy the operator into a local throwaway cluster (kind)
  
  ```sh
#!/usr/bin/env bash
set -eou pipefail

export IMG=quay.io/jack1902/trustee-operator:test
make docker-build IMG=$IMG
./tests/scripts/kind-with-registry.sh || true
kind load docker-image "${IMG}"
make install
make deploy IMG=$IMG
kubectl logs -n trustee-operator-system -l control-plane=controller-manager -f
````
  
</details>

<img width="913" height="302" alt="image" src="https://github.com/user-attachments/assets/9fae95d4-668a-4ca0-9006-1a43eb3ab845" />

Only bit i do observe within the logs is that lines such as `2026-05-29T13:36:01Z    INFO    kbsconfig-controller    Created a new deployment        {"kbsconfig": "", "Deployment.Namespace": "tenant-a", "Deployment.Name": "trustee-deployment"}` don't appear to actually hold the name of the kbsconfig

closes: #115

