### PR TITLE
fix(docs): align KBS kvstorage dir_path in samples and add NRAS GPU doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,17 +138,24 @@ data:
     type = "coco_as_grpc"
     as_addr = "http://127.0.0.1:50004"
 
+    [storage_backend]
+    storage_type = "LocalFs"
+
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/storage"
+
     [[plugins]]
     name = "resource"
-    type = "LocalFs"
-    dir_path = "/opt/confidential-containers/kbs/repository"
+    storage_backend_type = "kvstorage"
 
     [policy_engine]
-    policy_path = "/opt/confidential-containers/opa/policy.rego"
+    policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"
 
 ```
 
 If HTTPS support is not needed, please set `insecure_http=true` and no need to specify the attributes `private_key` and `certificate`.
+
+See [docs/kbs-kvstorage-storage.md](docs/kbs-kvstorage-storage.md) for `dir_path` semantics with the kvstorage resource plugin.
 
 An example configmap for AS config looks like this:
 

--- a/config/samples/all-in-one/ita-kbs-config.yaml
+++ b/config/samples/all-in-one/ita-kbs-config.yaml
@@ -25,10 +25,15 @@ data:
     certs_file = "https://portal.trustauthority.intel.com"
     allow_unmatched_policy = true
 
-    [[plugins]]
-    name = "resource"
-    type = "LocalFs"
-    dir_path = "/opt/confidential-containers/storage/repository"
+    [storage_backend]
+    storage_type = "LocalFs"
+
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/storage"
 
     [policy_engine]
     policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"
+
+    [[plugins]]
+    name = "resource"
+    storage_backend_type = "kvstorage"

--- a/config/samples/all-in-one/kbs-config.yaml
+++ b/config/samples/all-in-one/kbs-config.yaml
@@ -40,11 +40,15 @@ data:
         [attestation_service.rvps_config.storage.backends.local_json]
         file_dir_path = "/opt/confidential-containers/storage/local_json"
 
-    [[plugins]]
-    name = "resource"
-    type = "LocalFs"
-    dir_path = "/opt/confidential-containers/storage/repository"
+    [storage_backend]
+    storage_type = "LocalFs"
+
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/storage"
 
     [policy_engine]
     policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"
 
+    [[plugins]]
+    name = "resource"
+    storage_backend_type = "kvstorage"

--- a/config/samples/microservices/as-config.yaml
+++ b/config/samples/microservices/as-config.yaml
@@ -18,5 +18,11 @@ data:
         },
         "attestation_token_config": {
           "duration_min": 5
+        },
+        "verifier_config": {
+          "nvidia_verifier": {
+            "type": "Remote",
+            "verifier_url": "https://nras.attestation.nvidia.com/v4/attest"
+          }
         }
     }

--- a/config/samples/microservices/ita-kbs-config.yaml
+++ b/config/samples/microservices/ita-kbs-config.yaml
@@ -25,10 +25,15 @@ data:
     certs_file = "https://portal.trustauthority.intel.com"
     allow_unmatched_policy = true
 
-    [[plugins]]
-    name = "resource"
-    type = "LocalFs"
-    dir_path = "/opt/confidential-containers/storage/repository"
+    [storage_backend]
+    storage_type = "LocalFs"
+
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/storage"
 
     [policy_engine]
     policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"
+
+    [[plugins]]
+    name = "resource"
+    storage_backend_type = "kvstorage"

--- a/config/samples/microservices/kbs-config.yaml
+++ b/config/samples/microservices/kbs-config.yaml
@@ -22,10 +22,17 @@ data:
     type = "coco_as_grpc"
     as_addr = "http://127.0.0.1:50004"
 
-    [[plugins]]
-    name = "resource"
-    type = "LocalFs"
-    dir_path = "/opt/confidential-containers/storage/repository"
+    [storage_backend]
+    storage_type = "LocalFs"
+
+    # Base path only — kvstorage namespace "repository" resolves to
+    # /opt/confidential-containers/storage/repository/ (see docs/kbs-kvstorage-storage.md).
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/storage"
 
     [policy_engine]
     policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"
+
+    [[plugins]]
+    name = "resource"
+    storage_backend_type = "kvstorage"

--- a/docs/ita.md
+++ b/docs/ita.md
@@ -71,8 +71,8 @@ data:
           "trusted_certs_paths": ["https://portal.trustauthority.intel.com"]
         },
         "repository_config": {
-          "type": "LocalFs",
-          "dir_path": "/opt/confidential-containers/kbs/repository"
+          "type": "kvstorage",
+          "dir_path": "/opt/confidential-containers/storage"
         },
         "as_config": {
           "work_dir": "/opt/confidential-containers/attestation-service",

--- a/docs/kbs-kvstorage-storage.md
+++ b/docs/kbs-kvstorage-storage.md
@@ -1,0 +1,61 @@
+# KBS kvstorage `dir_path` configuration
+
+KBS v0.20+ uses the unified `storage_backend` with the resource plugin
+`storage_backend_type = "kvstorage"`. The KV namespace for secrets is
+`repository`, so files are stored under:
+
+```
+{dir_path}/repository/{repo}/{type}/{tag}
+```
+
+## Correct configuration
+
+Set **only the base path** in `[storage_backend.backends.local_fs]`:
+
+```toml
+[storage_backend]
+storage_type = "LocalFs"
+
+[storage_backend.backends.local_fs]
+dir_path = "/opt/confidential-containers/storage"
+
+[[plugins]]
+name = "resource"
+storage_backend_type = "kvstorage"
+```
+
+A secret at KBS path `default/nvcr-credentials/nvcr-auth.json` is stored at:
+
+```
+/opt/confidential-containers/storage/repository/default/nvcr-credentials/nvcr-auth.json
+```
+
+This matches the trustee-operator `secret-converter` init container layout.
+
+## Common misconfiguration
+
+Do **not** set `dir_path` to `.../storage/repository` when using `kvstorage`.
+That double-nests paths to `.../storage/repository/repository/...` and breaks
+NVCR credential release. Guest image pull then fails with CDH errors such as
+`ttrpc request error` or `Initialize resource provider failed` even when
+attestation succeeds.
+
+The legacy `LocalFs` plugin form (`type = "LocalFs"` with `dir_path = ".../repository"`)
+is deprecated for new deployments; use `storage_backend` + `kvstorage` instead.
+
+## Post-deploy verification
+
+After applying or updating KBS configuration:
+
+```bash
+# Confirm dir_path in the running KBS container
+kubectl exec -n trustee-operator-system deploy/trustee-deployment -c kbs -- \
+  grep dir_path /etc/kbs-config/kbs-config.toml
+
+# During a confidential pod start, KBS logs should show:
+# POST /kbs/v0/attest 200
+# GET .../default/nvcr-credentials/nvcr-auth.json 200
+kubectl logs -n trustee-operator-system deploy/trustee-deployment -c kbs --tail=50
+```
+
+See also [KBS storage documentation](https://github.com/confidential-containers/trustee/blob/main/kbs/docs/storage.md).

--- a/docs/nvidia-nras-gpu-verifier.md
+++ b/docs/nvidia-nras-gpu-verifier.md
@@ -1,0 +1,25 @@
+# NVIDIA GPU attestation (NRAS remote verifier)
+
+Blackwell (B200/B300) and other recent NVIDIA GPUs may fail local SPDM
+verification with *Device architecture not supported*. Use the NRAS remote
+verifier in the attestation service configuration.
+
+NRAS requires a licensing agreement with NVIDIA. See
+[trustee NVIDIA verifier documentation](https://github.com/confidential-containers/trustee/blob/main/deps/verifier/src/nvidia/README.md).
+
+## Microservices sample
+
+The [`as-config.yaml`](../config/samples/microservices/as-config.yaml) sample
+includes:
+
+```json
+"verifier_config": {
+  "nvidia_verifier": {
+    "type": "Remote",
+    "verifier_url": "https://nras.attestation.nvidia.com/v4/attest"
+  }
+}
+```
+
+Apply custom attestation policies after AS rollout if embedded defaults are
+insufficient — see [attestation-service policy docs](https://github.com/confidential-containers/trustee/blob/main/attestation-service/docs/policy.md).

--- a/docs/sticky-sessions.md
+++ b/docs/sticky-sessions.md
@@ -67,13 +67,18 @@ data:
         type = "LocalJson"
         file_path = "/opt/confidential-containers/rvps/reference-values/reference-values.json"
 
+    [storage_backend]
+    storage_type = "LocalFs"
+
+    [storage_backend.backends.local_fs]
+    dir_path = "/opt/confidential-containers/storage"
+
     [[plugins]]
     name = "resource"
-    type = "LocalFs"
-    dir_path = "/opt/confidential-containers/kbs/repository"
+    storage_backend_type = "kvstorage"
 
     [policy_engine]
-    policy_path = "/opt/confidential-containers/opa/policy.rego"
+    policy_path = "/opt/confidential-containers/storage/kbs/resource-policy.rego"
 EOF
 
 kubectl apply -f - << EOF


### PR DESCRIPTION
## Summary

- Fix KBS ConfigMap samples to use `storage_backend` base `dir_path` + `kvstorage` plugin (avoids double-nested `.../repository/repository` paths that break NVCR credential release)
- Add [docs/kbs-kvstorage-storage.md](docs/kbs-kvstorage-storage.md) with verification steps
- Add NRAS remote GPU verifier to microservices `as-config.yaml` and [docs/nvidia-nras-gpu-verifier.md](docs/nvidia-nras-gpu-verifier.md) for Blackwell B200/B300

Fixes #156

## Test plan

- [ ] `kubectl apply -k config/samples/microservices/` renders KBS config with base dir_path only
- [ ] After deploy, `grep dir_path` in KBS container shows `/opt/confidential-containers/storage`
- [ ] NVCR secret release returns 200 during confidential pod start

Made with [Cursor](https://cursor.com)