### PR TITLE
Fix secret-converter to run as non-root with proper volume mounting

### DIFF
--- a/cmd/secret-converter/main.go
+++ b/cmd/secret-converter/main.go
@@ -23,31 +23,35 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	controllers "github.com/confidential-containers/trustee-operator/internal/controller"
 )
 
-const (
-	repoDir    = "/opt/confidential-containers/storage/repository"
-	defaultDir = "/opt/confidential-containers/storage/repository/default"
+var (
+	// Source directory where Kubernetes mounts the secrets
+	sourceDir = controllers.KbsSecretsMountPath
+	// Destination directory where KBS expects flat files
+	repoDir = controllers.RepositoryPath
 )
 
 func main() {
 	log.Println("Converting secret directories to flat files...")
 
-	// Check if default directory exists
-	if _, err := os.Stat(defaultDir); os.IsNotExist(err) {
-		log.Printf("No secrets found in %s, skipping conversion", defaultDir)
+	// Check if source directory exists
+	if _, err := os.Stat(sourceDir); os.IsNotExist(err) {
+		log.Printf("No secrets found in %s, skipping conversion", sourceDir)
 		return
 	} else if err != nil {
-		log.Fatalf("Error checking default directory: %v", err)
+		log.Fatalf("Error checking source directory: %v", err)
 	}
 
 	// Check if directory is empty
-	entries, err := os.ReadDir(defaultDir)
+	entries, err := os.ReadDir(sourceDir)
 	if err != nil {
-		log.Fatalf("Error reading default directory: %v", err)
+		log.Fatalf("Error reading source directory: %v", err)
 	}
 	if len(entries) == 0 {
-		log.Printf("No secrets found in %s, skipping conversion", defaultDir)
+		log.Printf("No secrets found in %s, skipping conversion", sourceDir)
 		return
 	}
 
@@ -58,7 +62,7 @@ func main() {
 		}
 
 		secretName := entry.Name()
-		secretPath := filepath.Join(defaultDir, secretName)
+		secretPath := filepath.Join(sourceDir, secretName)
 		log.Printf("Processing secret: %s", secretName)
 
 		if err := processSecretDir(secretName, secretPath); err != nil {
@@ -128,6 +132,12 @@ func copyFile(src, dst string) (err error) {
 			err = fmt.Errorf("closing source file: %w", cerr)
 		}
 	}()
+
+	// Ensure destination directory exists
+	destDir := filepath.Dir(dst)
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
 
 	destFile, err := os.Create(dst)
 	if err != nil {

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -44,20 +44,26 @@ const (
 
 	confidentialContainers = "confidential-containers"
 
-	defaultRepository = "default"
-
 	confidentialContainersPath = rootPath + "/" + confidentialContainers
 
-	repositoryPath = confidentialContainersPath + "/storage/repository"
+	RepositoryPath = confidentialContainersPath + "/storage/repository"
 
-	// Default KBS Resources Path
-	kbsResourcesPath = repositoryPath + "/" + defaultRepository
+	// Base storage path
+	baseStoragePath = confidentialContainersPath + "/storage"
+
+	// Base storage directory volume name
+	baseStorageDirVolume = "base-storage-dir"
+
+	// Temporary path for mounting secrets before conversion
+	KbsSecretsMountPath = "/tmp/kbs-secrets"
 
 	// KBS storage path
 	kbsStoragePath = confidentialContainersPath + "/storage/kbs"
 
 	// Resource policy directory volume name
 	resourcePolicyDirVolume = "resource-policy-dir"
+
+	repositoryDir = "repository-dir"
 
 	// Resource policy filename
 	resourcePolicyFilename = "resource-policy.rego"

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -356,25 +356,22 @@ func (r *KbsConfigReconciler) newKbsDeployment(ctx context.Context) (*appsv1.Dep
 	var asVM []corev1.VolumeMount
 	var rvpsVM []corev1.VolumeMount
 
-	// The paths /opt/confidential-containers and /opt/confidential-containers/storage/repository/default
-	// are mounted as a RW volume in memory to allow trustee components
-	// to have full access to the filesystem
-	// confidential-containers
-	volume, err := r.createEmptyDirVolume(confidentialContainers)
+	// kbs-config
+	volume, err := r.createConfigMapVolume(ctx, "kbs-config", r.kbsConfig.Spec.KbsConfigMapName)
 	if err != nil {
 		return nil, err
 	}
+	volumeMount := createVolumeMount(volume.Name, filepath.Join(kbsDefaultConfigPath, volume.Name))
 	volumes = append(volumes, *volume)
-	volumeMount := createVolumeMount(volume.Name, filepath.Join(rootPath, volume.Name))
 	kbsVM = append(kbsVM, volumeMount)
 
-	// kbs-config
-	volume, err = r.createConfigMapVolume(ctx, "kbs-config", r.kbsConfig.Spec.KbsConfigMapName)
+	// base storage directory - create empty writable directory for session storage
+	volume, err = r.createEmptyDirVolume(baseStorageDirVolume)
 	if err != nil {
 		return nil, err
 	}
-	volumeMount = createVolumeMount(volume.Name, filepath.Join(kbsDefaultConfigPath, volume.Name))
 	volumes = append(volumes, *volume)
+	volumeMount = createVolumeMount(volume.Name, baseStoragePath)
 	kbsVM = append(kbsVM, volumeMount)
 
 	// attestation policy directory - create empty writable directory
@@ -526,15 +523,29 @@ func (r *KbsConfigReconciler) newKbsDeployment(ctx context.Context) (*appsv1.Dep
 		kbsVM = append(kbsVM, volumeMount)
 	}
 
+	// repository directory - create empty writable directory for KBS resources
+	// This must exist before secret-converter tries to write to it
+	volume, err = r.createEmptyDirVolume(repositoryDir)
+	if err != nil {
+		return nil, err
+	}
+	volumes = append(volumes, *volume)
+	volumeMount = createVolumeMount(volume.Name, RepositoryPath)
+	kbsVM = append(kbsVM, volumeMount)
+
 	// kbs secret resources
+	// Mount secrets to /tmp/kbs-secrets/<secret-name> temporarily
+	// The secret-converter init container will copy them to the final location
 	kbsSecretVolumes, err := r.createKbsSecretResourcesVolume(ctx)
 	if err != nil {
 		return nil, err
 	}
 	volumes = append(volumes, kbsSecretVolumes...)
+	var secretConverterVM []corev1.VolumeMount
 	for _, vol := range kbsSecretVolumes {
-		volumeMount = createVolumeMount(vol.Name, filepath.Join(kbsResourcesPath, vol.Name))
-		kbsVM = append(kbsVM, volumeMount)
+		// Mount to temporary location for secret-converter to read
+		volumeMount = createVolumeMount(vol.Name, filepath.Join(KbsSecretsMountPath, vol.Name))
+		secretConverterVM = append(secretConverterVM, volumeMount)
 	}
 
 	// rvps directory - create empty writable directory for RVPS storage
@@ -601,7 +612,10 @@ func (r *KbsConfigReconciler) newKbsDeployment(ctx context.Context) (*appsv1.Dep
 	}
 
 	// Build the secret converter init container (fails fast if OPERATOR_IMAGE_NAME is not set)
-	secretConverterContainer, err := r.buildSecretConverterInitContainer(kbsVM)
+	// Pass both the confidential-containers volume (for writing) and secret volumes (for reading)
+	allSecretConverterVM := append([]corev1.VolumeMount{}, kbsVM...)
+	allSecretConverterVM = append(allSecretConverterVM, secretConverterVM...)
+	secretConverterContainer, err := r.buildSecretConverterInitContainer(allSecretConverterVM)
 	if err != nil {
 		return nil, err
 	}
@@ -747,15 +761,10 @@ func (r *KbsConfigReconciler) buildSecretConverterInitContainer(volumeMounts []c
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
-			// Must run as root to write to emptyDir directories created by secret mounts.
-			// Security: This is safe because:
-			// - Init container only, runs once before main containers
-			// - AllowPrivilegeEscalation=false prevents gaining additional privileges
-			// - All capabilities dropped
-			// - Seccomp profile restricts syscalls
-			// - Only writes to emptyDir volumes, not host filesystem
-			RunAsNonRoot: pointer(false),
-			RunAsUser:    pointer(int64(0)),
+			// Run as non-root for OpenShift compatibility
+			// Secrets are mounted to /tmp which is writable by any user
+			// Output is written to emptyDir volume which is also writable
+			RunAsNonRoot: pointer(true),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},


### PR DESCRIPTION
Changes:
- Mount secrets to /tmp/kbs-secrets instead of directly to repository path
- Add emptyDir volume for repository-dir before secret-converter runs
- Remove RunAsUser:0 requirement, now runs as non-root
- create empty writable directory for KBS session storage

This allows the init container to run under OpenShift's restricted SCC while maintaining full secret conversion functionality.