### PR TITLE
Fix infinite loop reconcile

### DIFF
--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -858,10 +859,13 @@ func buildEnvVars(r *KbsConfigReconciler, ctx context.Context) []corev1.EnvVar {
 		}
 	}
 
-	// Convert map to array
+	// Convert map to array with stable ordering
 	for k, v := range envVarsMap {
 		env = append(env, corev1.EnvVar{Name: k, Value: v})
 	}
+	sort.Slice(env, func(i, j int) bool {
+		return env[i].Name < env[j].Name
+	})
 
 	return env
 }

--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -26,6 +26,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -301,14 +302,15 @@ func (r *KbsConfigReconciler) deployOrUpdateKbsDeployment(ctx context.Context) (
 		return false, err
 	}
 	// Update the found deployment and write the result back if there are any changes
-	err = r.updateKbsDeployment(ctx, found)
+	updated, err := r.updateKbsDeployment(ctx, found)
 	if err != nil {
 		r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeWarning, "DeploymentUpdateFailed", "DeploymentUpdateFailed", err.Error())
 		return false, err
 	}
-	// Deployment updated successfully
-	r.log.Info("Updated Deployment", "Deployment.Namespace", r.namespace, "Deployment.Name", KbsDeploymentName)
-	r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "DeploymentUpdated", "DeploymentUpdated", "Trustee deployment updated successfully")
+	if updated {
+		r.log.Info("Updated Deployment", "Deployment.Namespace", r.namespace, "Deployment.Name", KbsDeploymentName)
+		r.Recorder.Eventf(r.kbsConfig, nil, corev1.EventTypeNormal, "DeploymentUpdated", "DeploymentUpdated", "Trustee deployment updated successfully")
+	}
 
 	return false, nil
 }
@@ -935,28 +937,29 @@ func (r *KbsConfigReconciler) getConfigMapVersionAnnotations(ctx context.Context
 
 // updateKbsDeployment updates an existing deployment for the KBS instance
 // Errors are logged by the callee and hence no error is logged in this method
-func (r *KbsConfigReconciler) updateKbsDeployment(ctx context.Context, deployment *appsv1.Deployment) error {
+func (r *KbsConfigReconciler) updateKbsDeployment(ctx context.Context, deployment *appsv1.Deployment) (bool, error) {
 	// re-generates the deployment
 	newDeployment, err := r.newKbsDeployment(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	// Update the entire template (spec + metadata including annotations)
-	// This ensures that changes to pod template annotations (e.g., ConfigMap versions)
-	// trigger a rolling restart
-	deployment.Spec.Template = *newDeployment.Spec.Template.DeepCopy()
-	// Update replicas if changed
-	deployment.Spec.Replicas = newDeployment.Spec.Replicas
+	desiredTemplate := newDeployment.Spec.Template.DeepCopy()
+	desiredReplicas := newDeployment.Spec.Replicas
+
+	if apiequality.Semantic.DeepEqual(deployment.Spec.Template, *desiredTemplate) &&
+		apiequality.Semantic.DeepEqual(deployment.Spec.Replicas, desiredReplicas) {
+		return false, nil
+	}
+
+	deployment.Spec.Template = *desiredTemplate
+	deployment.Spec.Replicas = desiredReplicas
 
 	err = r.Update(ctx, deployment)
 	if err != nil {
-		return err
-	} else {
-		// Deployment updated successfully
-		r.log.Info("Updated Deployment", "Deployment.Namespace", r.namespace, "Deployment.Name", "kbs-deployment")
-		return nil
+		return false, err
 	}
+	return true, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
The trustee-operator enters an infinite reconcile loop that continuously restarts the trustee-deployment pods, leaving the Trustee/KBS service permanently unavailable (IsReady: false).

  Symptoms:
  - trustee-deployment pods cycle through Terminating/Init states every ~1-2 seconds
  - Deployment revision count grows by ~120/hour (observed 2,500+ revisions in 21 hours)
  - Operator logs show "Updated Deployment" on every reconciliation with intermittent "the object has been modified" conflict errors
  - KbsConfig status is permanently IsReady: false

  Root Cause:

  Two bugs in the KbsConfig controller cause unnecessary deployment updates on every reconciliation:

  1. Unconditional deployment update (kbsconfig_controller.go, updateKbsDeployment). The function calls r.Update() on the deployment every reconciliation without checking if the spec
  actually changed. Since the controller watches its own Deployment via Owns(), the resourceVersion bump re-enqueues a reconcile, creating a self-sustaining loop.
  2. Non-deterministic env var ordering (kbsconfig_controller.go, buildEnvVars). Env vars are built from map iteration, producing a non-deterministic []EnvVar slice. Currently latent with a
  single env var, but triggers unnecessary rollouts when proxy settings or multiple env vars are configured.

  Fix:
  - Guard updateKbsDeployment() with a DeepEqual check before calling Update()
  - Sort env vars by name after building from map