### PR TITLE
add labels to secrets created by operator

### DIFF
--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -96,6 +96,24 @@ const (
 	kbsDefaultLocalCacheDir = "/opt/confidential-containers/attestation-service/kds-store/vcek"
 )
 
+func standardLabels(instanceName, component string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "trustee-operator",
+		"app.kubernetes.io/part-of":    "trustee",
+		"app.kubernetes.io/instance":   instanceName,
+		"app.kubernetes.io/component":  component,
+	}
+}
+
+func hasStandardLabels(existing map[string]string, expected map[string]string) bool {
+	for k, v := range expected {
+		if existing[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 func contains(list []string, s string) bool {
 	for _, v := range list {
 		if v == s {

--- a/internal/controller/trusteeconfig_controller.go
+++ b/internal/controller/trusteeconfig_controller.go
@@ -348,6 +348,22 @@ func (r *TrusteeConfigReconciler) mergeKbsConfigSpecs(generatedSpec, manualSpec 
 	return merged
 }
 
+// ensureSecretLabels patches standard labels onto an existing secret if missing.
+func (r *TrusteeConfigReconciler) ensureSecretLabels(ctx context.Context, secret *corev1.Secret, component string) error {
+	expected := standardLabels(r.trusteeConfig.Name, component)
+	if hasStandardLabels(secret.Labels, expected) {
+		return nil
+	}
+	if secret.Labels == nil {
+		secret.Labels = make(map[string]string)
+	}
+	for k, v := range expected {
+		secret.Labels[k] = v
+	}
+	r.log.Info("Patching standard labels onto existing secret", "Secret.Name", secret.Name)
+	return r.Update(ctx, secret)
+}
+
 // buildKbsConfigSpec builds the KbsConfigSpec based on TrusteeConfig.
 // Returns an error if any required resource cannot be created so that
 // Reconcile can return the error and let controller-runtime retry rather
@@ -683,6 +699,7 @@ func (r *TrusteeConfigReconciler) generateKbsAuthSecret(ctx context.Context) (*c
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: r.namespace,
+			Labels:    standardLabels(r.trusteeConfig.Name, "auth"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
@@ -709,6 +726,7 @@ func (r *TrusteeConfigReconciler) generateKbsSampleSecret(ctx context.Context) (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: r.namespace,
+			Labels:    standardLabels(r.trusteeConfig.Name, "sample"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
@@ -758,8 +776,11 @@ func (r *TrusteeConfigReconciler) createOrUpdateKbsAuthSecret(ctx context.Contex
 	} else if err != nil {
 		return err
 	} else {
-		// Secret already exists, preserve its content
+		// Secret already exists, preserve its content and ensure labels are added
 		r.log.Info("KBS auth secret already exists, preserving existing content", "Secret.Namespace", r.namespace, "Secret.Name", secretName)
+		if err := r.ensureSecretLabels(ctx, found, "auth"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -790,8 +811,11 @@ func (r *TrusteeConfigReconciler) createOrUpdateKbsSampleSecret(ctx context.Cont
 	} else if err != nil {
 		return err
 	} else {
-		// Secret already exists, preserve its content
+		// Secret already exists, preserve its content and ensure labels are added
 		r.log.Info("KBS sample secret already exists, preserving existing content", "Secret.Namespace", r.namespace, "Secret.Name", secretName)
+		if err := r.ensureSecretLabels(ctx, found, "sample"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -872,8 +896,11 @@ func (r *TrusteeConfigReconciler) createOrUpdateHttpsKeySecret(ctx context.Conte
 	} else if err != nil {
 		return err
 	} else {
-		// Secret already exists, preserve its content
+		// Secret already exists, preserve its content and ensure labels are added
 		r.log.Info("HTTPS key secret already exists, preserving existing content", "Secret.Namespace", r.namespace, "Secret.Name", secretName)
+		if err := r.ensureSecretLabels(ctx, found, "https"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -903,8 +930,11 @@ func (r *TrusteeConfigReconciler) createOrUpdateHttpsCertSecret(ctx context.Cont
 	} else if err != nil {
 		return err
 	} else {
-		// Secret already exists, preserve its content
+		// Secret already exists, preserve its content and ensure labels are added
 		r.log.Info("HTTPS certificate secret already exists, preserving existing content", "Secret.Namespace", r.namespace, "Secret.Name", secretName)
+		if err := r.ensureSecretLabels(ctx, found, "https"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -921,6 +951,7 @@ func (r *TrusteeConfigReconciler) generateHttpsKeySecret(keyData []byte) (*corev
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: r.namespace,
+			Labels:    standardLabels(r.trusteeConfig.Name, "https"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
@@ -943,6 +974,7 @@ func (r *TrusteeConfigReconciler) generateHttpsCertSecret(certData []byte) (*cor
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: r.namespace,
+			Labels:    standardLabels(r.trusteeConfig.Name, "https"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
@@ -1029,8 +1061,11 @@ func (r *TrusteeConfigReconciler) createOrUpdateAttestationKeySecret(ctx context
 	} else if err != nil {
 		return err
 	} else {
-		// Secret already exists, preserve its content
+		// Secret already exists, preserve its content and ensure labels are added
 		r.log.Info("Attestation key secret already exists, preserving existing content", "Secret.Namespace", r.namespace, "Secret.Name", secretName)
+		if err := r.ensureSecretLabels(ctx, found, "attestation"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1060,8 +1095,11 @@ func (r *TrusteeConfigReconciler) createOrUpdateAttestationCertSecret(ctx contex
 	} else if err != nil {
 		return err
 	} else {
-		// Secret already exists, preserve its content
+		// Secret already exists, preserve its content and ensure labels are added
 		r.log.Info("Attestation certificate secret already exists, preserving existing content", "Secret.Namespace", r.namespace, "Secret.Name", secretName)
+		if err := r.ensureSecretLabels(ctx, found, "attestation"); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -1078,6 +1116,7 @@ func (r *TrusteeConfigReconciler) generateAttestationCertSecret(certData []byte)
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: r.namespace,
+			Labels:    standardLabels(r.trusteeConfig.Name, "attestation"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,
@@ -1110,6 +1149,7 @@ func (r *TrusteeConfigReconciler) generateAttestationKeySecret(keyData []byte) (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: r.namespace,
+			Labels:    standardLabels(r.trusteeConfig.Name, "attestation"),
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: data,

--- a/tests/e2e/sample-trusteeconfig-restricted/15-assert-https-secrets.yaml
+++ b/tests/e2e/sample-trusteeconfig-restricted/15-assert-https-secrets.yaml
@@ -3,21 +3,41 @@ kind: Secret
 metadata:
   name: trusteeconfig-restricted-https-key-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-restricted
+    app.kubernetes.io/component: https
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: trusteeconfig-restricted-https-cert-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-restricted
+    app.kubernetes.io/component: https
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: trusteeconfig-restricted-attestation-key-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-restricted
+    app.kubernetes.io/component: attestation
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: trusteeconfig-restricted-attestation-cert-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-restricted
+    app.kubernetes.io/component: attestation

--- a/tests/e2e/sample-trusteeconfig-restricted/30-assert-auth-secret.yaml
+++ b/tests/e2e/sample-trusteeconfig-restricted/30-assert-auth-secret.yaml
@@ -3,3 +3,8 @@ kind: Secret
 metadata:
   name: trusteeconfig-restricted-auth-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-restricted
+    app.kubernetes.io/component: auth

--- a/tests/e2e/sample-trusteeconfig/30-assert-auth-secret.yaml
+++ b/tests/e2e/sample-trusteeconfig/30-assert-auth-secret.yaml
@@ -3,3 +3,8 @@ kind: Secret
 metadata:
   name: trusteeconfig-sample-auth-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-sample
+    app.kubernetes.io/component: auth

--- a/tests/e2e/trusteeconfig-self-healing/30-assert.yaml
+++ b/tests/e2e/trusteeconfig-self-healing/30-assert.yaml
@@ -7,3 +7,8 @@ kind: Secret
 metadata:
   name: trusteeconfig-sample-auth-secret
   namespace: trustee-operator-system
+  labels:
+    app.kubernetes.io/managed-by: trustee-operator
+    app.kubernetes.io/part-of: trustee
+    app.kubernetes.io/instance: trusteeconfig-sample
+    app.kubernetes.io/component: auth


### PR DESCRIPTION
  - Add standard app.kubernetes.io/* labels (managed-by, part-of, instance, component) to all Secrets created by the TrusteeConfig reconciler, making it easy to identify their origin and purpose via kubectl get secrets -l app.kubernetes.io/managed-by=trustee-operator
  - Existing Secrets created before this change are automatically patched with labels on the next reconciliation (upgrade path)
  - Updated KUTTL e2e assertions for sample-trusteeconfig, sample-trusteeconfig-restricted, and trusteeconfig-self-healing suites to verify labels are present

  Fixes #169