### PR TITLE
Enable health endpoint on the kbs pods

### DIFF
--- a/internal/controller/kbsconfig_controller.go
+++ b/internal/controller/kbsconfig_controller.go
@@ -785,6 +785,39 @@ func (r *KbsConfigReconciler) buildKbsContainer(volumeMounts []corev1.VolumeMoun
 		"/etc/kbs-config/kbs-config.toml",
 	}
 
+	probeScheme := corev1.URISchemeHTTP
+	if r.isHttpsConfigPresent() {
+		probeScheme = corev1.URISchemeHTTPS
+	}
+
+	healthProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   intstr.FromInt32(8080),
+				Scheme: probeScheme,
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       10,
+		TimeoutSeconds:      5,
+		FailureThreshold:    3,
+	}
+
+	livenessProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   intstr.FromInt32(8080),
+				Scheme: probeScheme,
+			},
+		},
+		InitialDelaySeconds: 15,
+		PeriodSeconds:       30,
+		TimeoutSeconds:      5,
+		FailureThreshold:    3,
+	}
+
 	return corev1.Container{
 		Name:  "kbs",
 		Image: imageName,
@@ -798,8 +831,10 @@ func (r *KbsConfigReconciler) buildKbsContainer(volumeMounts []corev1.VolumeMoun
 		Command:         command,
 		SecurityContext: securityContext,
 		// Add volume mount for KBS config
-		VolumeMounts: volumeMounts,
-		Env:          env,
+		VolumeMounts:   volumeMounts,
+		Env:            env,
+		ReadinessProbe: healthProbe,
+		LivenessProbe:  livenessProbe,
 	}
 }
 


### PR DESCRIPTION
While trying out the trustee, it was hard to find out if the trustee really came up. I used curl on the health endpoint, hence I thought its good to add that as a probe.

The /healthz endpoint was added to KBS in trustee#1398 (merged 2026-06-02), which returns HTTP 200 on the same port 8080 that serves the KBS API. However, the trustee-operator never wired up Kubernetes probes to use it. Without probes, Kubernetes has no way to detect if the KBS process hangs or fails to serve requests.

Pods stay in Running state even when unhealthy, and the deployment reports Available the moment the container starts, before KBS is actually ready to accept connections. This change adds readiness and liveness probes to the KBS container using HTTPGet against /healthz on port 8080, with the scheme (HTTP or HTTPS) auto-detected from the existing isHttpsConfigPresent() helper. This ensures traffic is only routed to pods that are genuinely serving, and hung processes are automatically restarted.